### PR TITLE
Add guard to usage timeseries, remove apikey query mode

### DIFF
--- a/openapiv2/hub.swagger.json
+++ b/openapiv2/hub.swagger.json
@@ -866,9 +866,6 @@
           "type": "string",
           "description": "Query for stats where this specific APIKey was used. If not specified then stats for all APIKeys are returned."
         },
-        "apikeyQueryMode": {
-          "$ref": "#/definitions/v1QueryMode"
-        },
         "feature": {
           "type": "string",
           "description": "Query for stats about a specific feature. If not specified then stats for all features are returned."
@@ -1394,12 +1391,9 @@
             "$ref": "#/definitions/v1UsageTSDataPoint"
           }
         },
-        "apikey": {
+        "feature": {
           "type": "string",
           "title": "Axes for this timeseries - may not be applicable if there are no axes being queried in report mode"
-        },
-        "feature": {
-          "type": "string"
         },
         "priority": {
           "type": "integer",
@@ -1411,6 +1405,9 @@
             "type": "object",
             "$ref": "#/definitions/hubv1Tag"
           }
+        },
+        "guard": {
+          "type": "string"
         }
       }
     },

--- a/openapiv2/hub.swagger.json
+++ b/openapiv2/hub.swagger.json
@@ -847,9 +847,13 @@
     "v1GetUsageRequest": {
       "type": "object",
       "properties": {
-        "selector": {
-          "$ref": "#/definitions/v1GuardSelector",
+        "environment": {
+          "type": "string",
           "description": "If specified, only stats relating to the tags and features in selector will be returned.\n If only guard and environment are specified, then stats relating to all tags and features will be returned."
+        },
+        "guard": {
+          "type": "string",
+          "description": "Query for stats for this specific guard. If not specified then stats for all guards are returned."
         },
         "guardQueryMode": {
           "$ref": "#/definitions/v1QueryMode"
@@ -903,7 +907,7 @@
       },
       "description": "Usage query.",
       "required": [
-        "selector",
+        "environment",
         "startTs",
         "endTs"
       ]

--- a/stanza/hub/v1/usage.proto
+++ b/stanza/hub/v1/usage.proto
@@ -24,23 +24,24 @@ service UsageService {
 message GetUsageRequest {
   // If specified, only stats relating to the tags and features in selector will be returned.
   //  If only guard and environment are specified, then stats relating to all tags and features will be returned.
-  GuardSelector selector = 1 [(google.api.field_behavior) = REQUIRED];
+  string environment = 1 [(google.api.field_behavior) = REQUIRED];
+  optional string guard = 2; // Query for stats for this specific guard. If not specified then stats for all guards are returned.
 
-  optional QueryMode guard_query_mode = 2;
-  google.protobuf.Timestamp start_ts = 3 [(google.api.field_behavior) = REQUIRED];
-  google.protobuf.Timestamp end_ts = 4 [(google.api.field_behavior) = REQUIRED];
+  optional QueryMode guard_query_mode = 3;
+  google.protobuf.Timestamp start_ts = 4 [(google.api.field_behavior) = REQUIRED];
+  google.protobuf.Timestamp end_ts = 5 [(google.api.field_behavior) = REQUIRED];
 
-  optional string apikey = 5; // Query for stats where this specific APIKey was used. If not specified then stats for all APIKeys are returned.
+  optional string apikey = 6; // Query for stats where this specific APIKey was used. If not specified then stats for all APIKeys are returned.
 
-  optional string feature = 6; // Query for stats about a specific feature. If not specified then stats for all features are returned.
-  optional QueryMode feature_query_mode = 7;
+  optional string feature = 7; // Query for stats about a specific feature. If not specified then stats for all features are returned.
+  optional QueryMode feature_query_mode = 8;
 
-  optional int32 priority = 8; // Query for stats about a specific priority level. If not specified then stats for all priorities are returned.
-  optional QueryMode priority_query_mode = 9;
+  optional int32 priority = 9; // Query for stats about a specific priority level. If not specified then stats for all priorities are returned.
+  optional QueryMode priority_query_mode = 10;
 
-  repeated string report_tags = 10; // Tags matching listed tag keys will be reported (individual timeseries returned for each value).
-  repeated Tag tags = 11; // Only stats relating to the specified tags will be returned.
-  optional bool report_all_tags = 12; // Report all tag values for all tags as separate timeseries. Overrides tags and report_tags params.
+  repeated string report_tags = 11; // Tags matching listed tag keys will be reported (individual timeseries returned for each value).
+  repeated Tag tags = 12; // Only stats relating to the specified tags will be returned.
+  optional bool report_all_tags = 13; // Report all tag values for all tags as separate timeseries. Overrides tags and report_tags params.
 }
 
 message GetUsageResponse {

--- a/stanza/hub/v1/usage.proto
+++ b/stanza/hub/v1/usage.proto
@@ -31,17 +31,16 @@ message GetUsageRequest {
   google.protobuf.Timestamp end_ts = 4 [(google.api.field_behavior) = REQUIRED];
 
   optional string apikey = 5; // Query for stats where this specific APIKey was used. If not specified then stats for all APIKeys are returned.
-  optional QueryMode apikey_query_mode = 6;
 
-  optional string feature = 7; // Query for stats about a specific feature. If not specified then stats for all features are returned.
-  optional QueryMode feature_query_mode = 8;
+  optional string feature = 6; // Query for stats about a specific feature. If not specified then stats for all features are returned.
+  optional QueryMode feature_query_mode = 7;
 
-  optional int32 priority = 9; // Query for stats about a specific priority level. If not specified then stats for all priorities are returned.
-  optional QueryMode priority_query_mode = 10;
+  optional int32 priority = 8; // Query for stats about a specific priority level. If not specified then stats for all priorities are returned.
+  optional QueryMode priority_query_mode = 9;
 
-  repeated string report_tags = 11; // Tags matching listed tag keys will be reported (individual timeseries returned for each value).
-  repeated Tag tags = 12; // Only stats relating to the specified tags will be returned.
-  optional bool report_all_tags = 13; // Report all tag values for all tags as separate timeseries. Overrides tags and report_tags params.
+  repeated string report_tags = 10; // Tags matching listed tag keys will be reported (individual timeseries returned for each value).
+  repeated Tag tags = 11; // Only stats relating to the specified tags will be returned.
+  optional bool report_all_tags = 12; // Report all tag values for all tags as separate timeseries. Overrides tags and report_tags params.
 }
 
 message GetUsageResponse {
@@ -51,10 +50,10 @@ message GetUsageResponse {
 message UsageTimeseries {
   repeated UsageTSDataPoint data = 1;
   // Axes for this timeseries - may not be applicable if there are no axes being queried in report mode
-  optional string apikey = 2;
   optional string feature = 3;
   optional int32 priority = 4;
   repeated Tag tags = 5;
+  optional string guard = 6;
 }
 
 message UsageTSDataPoint {


### PR DESCRIPTION
Breaking update, but nobody is using this yet.

We remove apikey query mode - not safe, don't want to expose apikeys.
Add guard to usage timeseries, to allow querying by feature. 