### PR TITLE
Tweak experimental streambalancer api

### DIFF
--- a/openapiv2/hub.swagger.json
+++ b/openapiv2/hub.swagger.json
@@ -1306,13 +1306,10 @@
     "v1StreamRequest": {
       "type": "object",
       "properties": {
-        "selector": {
-          "$ref": "#/definitions/v1GuardFeatureSelector"
-        },
         "priorityBoost": {
           "type": "integer",
           "format": "int32",
-          "description": "Used to increase or decrease priority of request, relative to normal feature priority. \nFor instance, a customer may wish to boost the priority of paid user traffic over free tier. Priority boosts may also be negative - for example, one might deprioritise bot traffic."
+          "description": "Used to increase or decrease priority of request, relative to normal feature priority.\nFor instance, a customer may wish to boost the priority of paid user traffic over free tier. Priority boosts may also be negative - for example, one might deprioritise bot traffic."
         },
         "streamId": {
           "type": "string",
@@ -1328,10 +1325,7 @@
           "format": "float",
           "description": "Minimum weight that may be allocated to this stream. If this weight cannot be allocated then the stream cannot be served."
         }
-      },
-      "required": [
-        "selector"
-      ]
+      }
     },
     "v1StreamResult": {
       "type": "object",
@@ -1462,6 +1456,9 @@
     "v1UpdateStreamsRequest": {
       "type": "object",
       "properties": {
+        "selector": {
+          "$ref": "#/definitions/v1GuardFeatureSelector"
+        },
         "requests": {
           "type": "array",
           "items": {
@@ -1469,7 +1466,10 @@
             "$ref": "#/definitions/v1StreamRequest"
           }
         }
-      }
+      },
+      "required": [
+        "selector"
+      ]
     },
     "v1UpdateStreamsResponse": {
       "type": "object",

--- a/stanza/hub/v1/stream.proto
+++ b/stanza/hub/v1/stream.proto
@@ -20,7 +20,8 @@ service StreamBalancerService {
 }
 
 message UpdateStreamsRequest {
-  repeated StreamRequest requests = 1;
+  GuardFeatureSelector selector = 1 [(google.api.field_behavior) = REQUIRED];
+  repeated StreamRequest requests = 2;
 }
 
 message UpdateStreamsResponse {
@@ -28,20 +29,18 @@ message UpdateStreamsResponse {
 }
 
 message StreamRequest {
-  GuardFeatureSelector selector = 1 [(google.api.field_behavior) = REQUIRED];
-
   // Used to increase or decrease priority of request, relative to normal feature priority.
   // For instance, a customer may wish to boost the priority of paid user traffic over free tier. Priority boosts may also be negative - for example, one might deprioritise bot traffic.
-  optional int32 priority_boost = 2;
+  optional int32 priority_boost = 1;
 
   // Unique identifier for this stream - may be meaningful or a UUID.
-  string stream_id = 3;
+  string stream_id = 2;
 
   // Maximum weight that may be allocated to this stream
-  float max_weight = 4;
+  float max_weight = 3;
 
   // Minimum weight that may be allocated to this stream. If this weight cannot be allocated then the stream cannot be served.
-  float min_weight = 5;
+  float min_weight = 4;
 }
 
 message StreamResult {


### PR DESCRIPTION
Selector should be toplevel here. Nobody is using this for sure so breaking change is ok for now.