### PR TITLE
Tweak experimental streambalancer api again

### DIFF
--- a/openapiv2/hub.swagger.json
+++ b/openapiv2/hub.swagger.json
@@ -1306,10 +1306,22 @@
     "v1StreamRequest": {
       "type": "object",
       "properties": {
+        "feature": {
+          "type": "string",
+          "title": "optional"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/hubv1Tag"
+          },
+          "title": "optional"
+        },
         "priorityBoost": {
           "type": "integer",
           "format": "int32",
-          "description": "Used to increase or decrease priority of request, relative to normal feature priority.\nFor instance, a customer may wish to boost the priority of paid user traffic over free tier. Priority boosts may also be negative - for example, one might deprioritise bot traffic."
+          "title": "optional"
         },
         "streamId": {
           "type": "string",
@@ -1325,7 +1337,13 @@
           "format": "float",
           "description": "Minimum weight that may be allocated to this stream. If this weight cannot be allocated then the stream cannot be served."
         }
-      }
+      },
+      "description": "Used to increase or decrease priority of request, relative to normal feature priority.\n For instance, a customer may wish to boost the priority of paid user traffic over free tier. Priority boosts may also be negative - for example, one might deprioritise bot traffic.",
+      "required": [
+        "streamId",
+        "maxWeight",
+        "minWeight"
+      ]
     },
     "v1StreamResult": {
       "type": "object",
@@ -1339,7 +1357,10 @@
           "format": "float",
           "description": "Weight allocated to this stream. Zero means it was not allocated."
         }
-      }
+      },
+      "required": [
+        "streamId"
+      ]
     },
     "v1TokenInfo": {
       "type": "object",
@@ -1456,8 +1477,11 @@
     "v1UpdateStreamsRequest": {
       "type": "object",
       "properties": {
-        "selector": {
-          "$ref": "#/definitions/v1GuardFeatureSelector"
+        "guardName": {
+          "type": "string"
+        },
+        "environment": {
+          "type": "string"
         },
         "requests": {
           "type": "array",
@@ -1475,7 +1499,8 @@
         }
       },
       "required": [
-        "selector"
+        "guardName",
+        "environment"
       ]
     },
     "v1UpdateStreamsResponse": {

--- a/stanza/hub/v1/stream.proto
+++ b/stanza/hub/v1/stream.proto
@@ -22,7 +22,7 @@ service StreamBalancerService {
 message UpdateStreamsRequest {
   string guard_name = 1 [(google.api.field_behavior) = REQUIRED];
   string environment = 2 [(google.api.field_behavior) = REQUIRED];
-  
+
   repeated StreamRequest requests = 3;
   repeated string ended = 4; // IDs of streams that have completed
 }
@@ -34,8 +34,8 @@ message UpdateStreamsResponse {
 message StreamRequest {
   // Used to increase or decrease priority of request, relative to normal feature priority.
   // For instance, a customer may wish to boost the priority of paid user traffic over free tier. Priority boosts may also be negative - for example, one might deprioritise bot traffic.
-  
-  string feature = 1;   // optional
+
+  string feature = 1; // optional
 
   repeated Tag tags = 2; // optional
 

--- a/stanza/hub/v1/stream.proto
+++ b/stanza/hub/v1/stream.proto
@@ -20,9 +20,11 @@ service StreamBalancerService {
 }
 
 message UpdateStreamsRequest {
-  GuardFeatureSelector selector = 1 [(google.api.field_behavior) = REQUIRED];
-  repeated StreamRequest requests = 2;
-  repeated string ended = 3; // IDs of streams that have completed
+  string guard_name = 1 [(google.api.field_behavior) = REQUIRED];
+  string environment = 2 [(google.api.field_behavior) = REQUIRED];
+  
+  repeated StreamRequest requests = 3;
+  repeated string ended = 4; // IDs of streams that have completed
 }
 
 message UpdateStreamsResponse {
@@ -32,21 +34,26 @@ message UpdateStreamsResponse {
 message StreamRequest {
   // Used to increase or decrease priority of request, relative to normal feature priority.
   // For instance, a customer may wish to boost the priority of paid user traffic over free tier. Priority boosts may also be negative - for example, one might deprioritise bot traffic.
-  optional int32 priority_boost = 1;
+  
+  string feature = 1;   // optional
+
+  repeated Tag tags = 2; // optional
+
+  optional int32 priority_boost = 3; // optional
 
   // Unique identifier for this stream - may be meaningful or a UUID.
-  string stream_id = 2;
+  string stream_id = 4 [(google.api.field_behavior) = REQUIRED];
 
   // Maximum weight that may be allocated to this stream
-  float max_weight = 3;
+  float max_weight = 5 [(google.api.field_behavior) = REQUIRED];
 
   // Minimum weight that may be allocated to this stream. If this weight cannot be allocated then the stream cannot be served.
-  float min_weight = 4;
+  float min_weight = 6 [(google.api.field_behavior) = REQUIRED];
 }
 
 message StreamResult {
   // Unique identifier for this stream - may be meaningful or a UUID.
-  string stream_id = 1;
+  string stream_id = 1 [(google.api.field_behavior) = REQUIRED];
 
   // Weight allocated to this stream. Zero means it was not allocated.
   float allocated_weight = 2;


### PR DESCRIPTION
Guard and env apply to whole batch. 
But tags, feature and priority boost are per request.